### PR TITLE
Fix `ModuleNotFoundError` in conda environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ To build this, run the command below:
 bash install.sh
 ```
 
+By default, this script uses the `--user` option, which installs packages in your home directory. However, this approach can sometimes cause a `ModuleNotFoundError` when using a `conda` environment. If you encounter this issue, reinstall the packages using the `--global` option:
+```
+bash install.sh --global
+```
+This command will install the extensions in your conda environment location instead of your home directory, preventing the error.
+
 ## Preparing the Data
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,27 +1,24 @@
 #!/usr/bin/env sh
+
+# Usage:
+#   bash install.sh          - Install packages with --user flag (in user's home directory)
+#   bash install.sh --global - Install packages globally (may require root privileges, depending on the python interpreter used)
+
 HOME=`pwd`
 
-# Check if CUDA is available
-if python -c "import torch; print(torch.cuda.is_available())" | grep -q True; then
-    echo "CUDA detected, forcing CUDA build for both extensions..."
-    USE_CUDA=1
+# Parse command-line arguments
+USE_USER_FLAG="--user"
+if [ "$1" = "--global" ]; then
+    USE_USER_FLAG=""
+    echo "Installing globally."
 else
-    echo "No CUDA detected, proceeding with standard build..."
-    USE_CUDA=0
+    echo "Installing with --user flag in user's home directory."
 fi
 
 # Chamfer Distance
 cd $HOME/extensions/chamfer_dist
-if [ "$USE_CUDA" = "1" ]; then
-    FORCE_CUDA=1 python setup.py install --user
-else
-    python setup.py install --user
-fi
+python setup.py install $USE_USER_FLAG
 
 # PointOps
 cd $HOME/extensions/pointops
-if [ "$USE_CUDA" = "1" ]; then
-    FORCE_CUDA=1 python setup.py install --user
-else
-    python setup.py install --user
-fi
+python setup.py install $USE_USER_FLAG


### PR DESCRIPTION
This PR supersedes my previous solution (PR #29) to issues #12 and #23  that incorrectly relied on `FORCE_CUDA`. That approach masked the real issue, only working in my local setup due to additional dependencies that are not relevant in a clean environment.

Key changes:
1. Removes unnecessary `FORCE_CUDA` workaround (as FORCE_CUDA is never used in this project's setup files)
2. Adds optional global installation for compiled extensions in conda (Resolving `ModuleNotFoundError` )
3. Maintains default local installation behavior

This solution properly addresses the module discovery issue while aligning with the project's existing setup procedure. Apologies for the confusion from my previous PR.